### PR TITLE
Rewrote Repo.shell to use argument lists instead of shell=True

### DIFF
--- a/wib/cli.py
+++ b/wib/cli.py
@@ -86,15 +86,14 @@ def commit(context, message, name):
     name    - tag name
     """
     context.obj.find_repo_type()
-    quoted_message = '"{}"'.format(message)
     if context.obj.vc_name == 'git':
-        context.obj.call(['git', 'commit', '-a', '-m', quoted_message])
+        context.obj.call(['git', 'commit', '-a', '-m', message])
     elif context.obj.vc_name == 'hg':
-        context.obj.call(['hg', 'commit', '-m', quoted_message])
+        context.obj.call(['hg', 'commit', '-m', message])
     if name != '' and context.obj.vc_name == 'git':
-        context.obj.call(['git', 'tag', '-a', name, '-m', quoted_message])
+        context.obj.call(['git', 'tag', '-a', name, '-m', message])
     elif name != '' and context.obj.vc_name == 'hg':
-        context.obj.call(['hg', 'tag', '-m', quoted_message, name])
+        context.obj.call(['hg', 'tag', '-m', message, name])
 
 
 @main.command()


### PR DESCRIPTION
I rewrote the `Repo.shell` function to call commands with an argument list instead of using the shell. This automatically handles escaping (so the quotes + spaces escaping is no longer a problem, at least not on Windows), and fixes `wib log` on Windows. It also neatens up some of the code, since concatenating filenames and command strings is no longer required. I've renamed `shell` to `call` to better mirror the `subprocess` API given that the function no longer uses the shell.

I haven't figured out how to pipe into `less`, so the only thing that this pull request should break is `hg log | less`, which has been replaced by `hg log`. There's a way around it, I'm just unsure what. (Possibly paginating from Python is neater than using `less`, but I'm not sure about that either.)

I haven't tested this on `hg`, as I have neither Mercurial nor any Mercurial repositories...